### PR TITLE
Fix compiling with gcc 4.8 on linux

### DIFF
--- a/Source/ARX/ARG/CMakeLists.txt
+++ b/Source/ARX/ARG/CMakeLists.txt
@@ -27,6 +27,10 @@ set(SOURCE
     shader_gl.c
 )
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set_source_files_properties(arg_gl3.c PROPERTIES COMPILE_FLAGS "-std=c99")
+endif()
+
 add_library(ARG STATIC
     ${PUBLIC_HEADERS} ${SOURCE}
 )

--- a/Source/ARX/ARUtil/CMakeLists.txt
+++ b/Source/ARX/ARUtil/CMakeLists.txt
@@ -63,6 +63,10 @@ set(SOURCE
     zip.c
 )
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set_source_files_properties(file_utils.c PROPERTIES COMPILE_FLAGS "-std=c99")
+endif()
+
 if (ARX_TARGET_PLATFORM_ANDROID)
     set(SOURCE ${SOURCE}
         ftw.h

--- a/Source/ARX/ARVideo/CMakeLists.txt
+++ b/Source/ARX/ARVideo/CMakeLists.txt
@@ -45,6 +45,11 @@ set(PUBLIC_HEADERS
     include/ARX/ARVideo/videoRGBA.h
 )
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set_source_files_properties(cparamSearch.c PROPERTIES COMPILE_FLAGS "-std=c99")
+    set_source_files_properties(videoRGBA.c PROPERTIES COMPILE_FLAGS "-std=c99")
+endif()
+
 set(INCLUDE_DIRS
     ${JPEG_INCLUDE_DIR}
 )


### PR DESCRIPTION
This commit fixes compile error: ‘for’ loop initial declarations are only
allowed in C99 mode.