### PR TITLE
Export some classes to fix compilation of the utility check_id on windows.

### DIFF
--- a/Source/ARX/include/ARX/ARVideoSource.h
+++ b/Source/ARX/include/ARX/ARVideoSource.h
@@ -50,7 +50,7 @@
  * contain information about the video, such as size and pixel format, camera parameters
  * for distortion compensation, as well as the raw video data itself.
  */
-class ARVideoSource {
+class ARX_EXTERN ARVideoSource {
 
 private:
 

--- a/Source/ARX/include/ARX/ARVideoView.h
+++ b/Source/ARX/include/ARX/ARVideoView.h
@@ -52,7 +52,7 @@
  * context must be initialised and active at the time of the call. For most OpenGL
  * implementations, such a call can only be made from a rendering thread.
  */
-class ARVideoView {
+class ARX_EXTERN ARVideoView {
 
 public:
 


### PR DESCRIPTION
This commit fixes the build of the utility check_id on windows with the msvc 2017 compiler.