### PR TITLE
Android : Add more linkages via JNI and functions for 2D Tracking

### DIFF
--- a/Source/ARX/ARTrackable2d.cpp
+++ b/Source/ARX/ARTrackable2d.cpp
@@ -113,6 +113,11 @@ bool ARTrackable2d::unload()
     return true;
 }
 
+char* ARTrackable2d::getDatasetPathname() 
+{
+    return datasetPathname;
+}
+
 bool ARTrackable2d::updateWithTwoDResults(int detectedPage, float trackingTrans[3][4], ARdouble transL2R[3][4])
 {
     if (!m_loaded) return false;

--- a/Source/ARX/ARTrackableNFT.cpp
+++ b/Source/ARX/ARTrackableNFT.cpp
@@ -95,6 +95,11 @@ bool ARTrackableNFT::unload()
 	return true;
 }
 
+char* ARTrackableNFT::getDatasetPathname() 
+{
+    return datasetPathname;
+}
+
 bool ARTrackableNFT::updateWithNFTResults(int detectedPage, float trackingTrans[3][4], ARdouble transL2R[3][4])
 {
     if (!m_loaded) return false;

--- a/Source/ARX/ARX_c.cpp
+++ b/Source/ARX/ARX_c.cpp
@@ -432,6 +432,31 @@ int arwAddTrackable(const char *cfg)
 	return gARTK->addTrackable(cfg);
 }
 
+int arwCountTrackables()
+{
+	if(!gARTK) return -1;
+	return gARTK->countTrackables();
+}
+
+int arwGetTrackableUIDAtIndex(int i)
+{
+	if(!gARTK) return -1;
+	return gARTK->getTrackableAtIndex(i)->UID;
+}
+
+char* arwGetTrackableNameAtIndex(int i)
+{
+    if(!gARTK) return NULL;
+
+    if(dynamic_cast<ARTrackable2d*>(gARTK->getTrackableAtIndex(i))) {
+        return ((ARTrackable2d*)gARTK->getTrackableAtIndex(i))->getDatasetPathname();
+    } else if(dynamic_cast<ARTrackableNFT*>(gARTK->getTrackableAtIndex(i))) {
+        return ((ARTrackableNFT*)gARTK->getTrackableAtIndex(i))->getDatasetPathname();
+    } else {
+        return NULL;
+    }
+}
+
 bool arwGetTrackables(int *count_p, ARWTrackableStatus **statuses_p)
 {
     if (!gARTK) return false;
@@ -835,6 +860,10 @@ extern "C" {
     JNIEXPORT jboolean JNICALL JNIFUNCTION(arwDrawVideo(JNIEnv *env, jobject obj, jint videoSourceIndex));
     JNIEXPORT jboolean JNICALL JNIFUNCTION(arwDrawVideoFinal(JNIEnv *env, jobject obj, jint videoSourceIndex));
 	JNIEXPORT jint JNICALL JNIFUNCTION(arwAddTrackable(JNIEnv *env, jobject obj, jstring cfg));
+	JNIEXPORT jboolean JNICALL JNIFUNCTION(arwLoad2dTrackableDatabase(JNIEnv *env, jobject obj, jstring databaseFileName));
+	JNIEXPORT jint JNICALL JNIFUNCTION(arwCountTrackables(JNIEnv *env, jobject obj));
+	JNIEXPORT jint JNICALL JNIFUNCTION(arwGetTrackableUIDAtIndex(JNIEnv *env, jobject obj, jint i));
+    JNIEXPORT jstring JNICALL JNIFUNCTION(arwGetTrackableNameAtIndex(JNIEnv *env, jobject obj, jint i));
 	JNIEXPORT jboolean JNICALL JNIFUNCTION(arwRemoveTrackable(JNIEnv *env, jobject obj, jint trackableUID));
 	JNIEXPORT jint JNICALL JNIFUNCTION(arwRemoveAllTrackables(JNIEnv *env, jobject obj));
     JNIEXPORT jboolean JNICALL JNIFUNCTION(arwQueryTrackableVisibilityAndTransformation(JNIEnv *env, jobject obj, jint trackableUID, jfloatArray matrix));
@@ -1086,6 +1115,31 @@ JNIEXPORT jint JNICALL JNIFUNCTION(arwAddTrackable(JNIEnv *env, jobject obj, jst
 	int trackableUID = arwAddTrackable(cfgC);
 	env->ReleaseStringUTFChars(cfg, cfgC);
 	return trackableUID;
+}
+
+JNIEXPORT jboolean JNICALL JNIFUNCTION(arwLoad2dTrackableDatabase(JNIEnv *env, jobject obj, jstring databaseFileName))
+{
+	jboolean isCopy;
+
+	const char *databaseFileNameC = env->GetStringUTFChars(databaseFileName, &isCopy);
+	bool answer = arwLoad2dTrackableDatabase(databaseFileNameC);
+	env->ReleaseStringUTFChars(databaseFileName, databaseFileNameC);
+	return answer;
+}
+
+JNIEXPORT jint JNICALL JNIFUNCTION(arwCountTrackables(JNIEnv *env, jobject obj))
+{
+	return arwCountTrackables();
+}
+
+JNIEXPORT jint JNICALL JNIFUNCTION(arwGetTrackableUIDAtIndex(JNIEnv *env, jobject obj, jint i))
+{
+	return arwGetTrackableUIDAtIndex(i);
+}
+
+JNIEXPORT jstring JNICALL JNIFUNCTION(arwGetTrackableNameAtIndex(JNIEnv *env, jobject obj, jint i))
+{
+    return env->NewStringUTF(arwGetTrackableNameAtIndex(i));
 }
 
 JNIEXPORT jboolean JNICALL JNIFUNCTION(arwRemoveTrackable(JNIEnv *env, jobject obj, jint trackableUID)) 

--- a/Source/ARX/OCVT/include/ARX/OCVT/PlanarTracker.h
+++ b/Source/ARX/OCVT/include/ARX/OCVT/PlanarTracker.h
@@ -45,6 +45,7 @@
 #include <sstream>
 #include <iostream>
 #include <vector>
+#include <future>
 #include <ARX/AR/ar.h> // ARdouble
 class TrackedImageInfo
 {

--- a/Source/ARX/include/ARX/ARTrackable2d.h
+++ b/Source/ARX/include/ARX/ARTrackable2d.h
@@ -70,6 +70,8 @@ public:
     bool load(const char* dataSetPathname_in);
     bool load2DData(const char* dataSetPathname_in, std::shared_ptr<unsigned char> refImage, int m_refImageX, int m_refImageY);
 
+    char* getDatasetPathname();
+
     bool updateWithTwoDResults(int detectedPage, float trackingTrans[3][4], ARdouble transL2R[3][4] = NULL);
     
     void setTwoDScale(const float scale);

--- a/Source/ARX/include/ARX/ARTrackableNFT.h
+++ b/Source/ARX/include/ARX/ARTrackableNFT.h
@@ -66,6 +66,8 @@ public:
 
 	bool load(const char* dataSetPathname_in);
 
+    	char* getDatasetPathname();
+
 	bool updateWithNFTResults(int detectedPage, float trackingTrans[3][4], ARdouble transL2R[3][4] = NULL);
 
     void setNFTScale(const float scale);

--- a/Source/ARX/include/ARX/ARX_c.h
+++ b/Source/ARX/include/ARX/ARX_c.h
@@ -467,6 +467,34 @@ extern "C" {
 	 * @return			The unique identifier (UID) of the trackable instantiated based on the configuration string, or -1 if an error occurred
 	 */
 	ARX_EXTERN int arwAddTrackable(const char *cfg);
+
+    /**
+     * Loads a 2D Trackable Database.
+     * This takes the database path as argument.
+     * @param databaseFileName   The database path
+     * @return                   Whether the operation succeeded or not.
+    */
+	ARX_EXTERN bool arwLoad2dTrackableDatabase(const char *databaseFileName);
+
+    /**
+     * Counts the number of loaded trackables.
+     * @return   The count of trackables, -1 if it failed.
+    */
+	ARX_EXTERN int arwCountTrackables();
+
+    /**
+     * Gets the UID of a trackable based on its index
+     * @param i      Index of the trackable object
+     * @return       UID of the trackable object
+    */
+	ARX_EXTERN int arwGetTrackableUIDAtIndex(int i);
+
+    /*
+     * Gets the filename of a trackable based on its index
+     * @param i      Index of the trackable object
+     * @return       Filename of the trackable object
+    */
+    ARX_EXTERN char* arwGetTrackableNameAtIndex(int i);
     
     typedef struct {
         int uid;

--- a/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARActivity.java
+++ b/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARActivity.java
@@ -183,7 +183,10 @@ public abstract class ARActivity extends /*AppCompat*/Activity implements View.O
         super.onResume();
 
         // Create the GL view
-        mGlView = new GLSurfaceView(this);
+        if(mGlView == null) {
+            Log.i(TAG, "onResume(): As there's no custom GLSurfaceView defined, a plain GLSurfaceView will be initialized.");
+            mGlView = new GLSurfaceView(this);
+        }
 
         FrameListener frameListener = new FrameListenerImpl(renderer, this, mGlView);
         CameraEventListener cameraEventListener = new CameraEventListenerImpl(this, frameListener);
@@ -321,6 +324,11 @@ public abstract class ARActivity extends /*AppCompat*/Activity implements View.O
     @SuppressWarnings("unused")
     public GLSurfaceView getGLView() {
         return mGlView;
+    }
+
+    @SuppressWarnings("unused")
+    public void setGLView(GLSurfaceView mGlView) {
+        this.mGlView = mGlView;
     }
 
     @SuppressWarnings("unused")

--- a/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARController.java
+++ b/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARController.java
@@ -272,6 +272,48 @@ public class ARController {
     }
 
     /**
+     * Loads a 2D Trackable Database.
+     *
+     * @param databaseFileName The database path & filename.
+    */
+	public boolean load2DTrackableDatabase(String databaseFileName) {
+		if (!initedNative) return false;
+		return ARX_jni.arwLoad2dTrackableDatabase(databaseFileName);
+	}
+
+    /**
+     * Counts the number of loaded trackables.
+     *
+     * @return   The count of trackables, -1 if it failed.
+    */
+	public int countTrackables() {
+		if (!initedNative) return -1;
+		return ARX_jni.arwCountTrackables();
+	}
+
+    /**
+     * Gets the UID of a trackable based on its index
+     *
+     * @param i      Index of the trackable object
+     * @return       UID of the trackable object
+    */
+	public int getTrackableUIDAtIndex(int i) {
+		if (!initedNative) return -1;
+		return ARX_jni.arwGetTrackableUIDAtIndex(i);
+	}
+
+    /*
+     * Gets the filename of a trackable based on its index
+     *
+     * @param i      Index of the trackable object
+     * @return       Filename of the trackable object
+    */
+    public String getTrackableNameAtIndex(int i) {
+        if (!initedNative) return null;
+        return ARX_jni.arwGetTrackableNameAtIndex(i);
+    }
+
+    /**
      * Returns whether the marker with the specified ID is currently visible, and if visible the trackable transformation.
      *
      * @param trackableUID The unique identifier (UID) of the trackable to query.

--- a/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARController.java
+++ b/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARController.java
@@ -313,6 +313,28 @@ public class ARController {
         return ARX_jni.arwGetTrackableNameAtIndex(i);
     }
 
+    /*
+     * Remove all trackables
+     *
+     * @return       Number of trackables removed
+    */
+    public int removeAllTrackables() {
+        if (!initedNative) return -1;
+        return ARX_jni.arwRemoveAllTrackables();
+    }
+
+    /*
+     * Remove specified trackable
+     *
+     * @param trackableUID The unique identifier (UID) of the trackable to remove
+     * @return true if the marker was removed, otherwise false
+    */
+    public boolean removeTrackable(int trackableUID) {
+        if (!initedNative) return false;
+        return ARX_jni.arwRemoveTrackable(trackableUID);
+    }
+
+
     /**
      * Returns whether the marker with the specified ID is currently visible, and if visible the trackable transformation.
      *

--- a/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARX_jni.java
+++ b/Source/ARXJ/ARXJProj/arxj/src/main/java/org/artoolkitx/arx/arxj/ARX_jni.java
@@ -409,6 +409,37 @@ public class ARX_jni {
     public static native int arwAddTrackable(String cfg);
 
     /**
+     * Loads a 2D Trackable Database.
+     *
+     * @param databaseFileName The database path & filename.
+     * @return Whether the operation succeeded or not.
+    */
+	public static native boolean arwLoad2dTrackableDatabase(String databaseFileName);
+
+    /**
+     * Counts the number of loaded trackables.
+     *
+     * @return   The count of trackables, -1 if it failed.
+    */
+	public static native int arwCountTrackables();
+
+    /**
+     * Gets the UID of a trackable based on its index
+     *
+     * @param i      Index of the trackable object
+     * @return       UID of the trackable object
+    */
+	public static native int arwGetTrackableUIDAtIndex(int i);
+
+    /*
+     * Gets the filename of a trackable based on its index
+     *
+     * @param i      Index of the trackable object
+     * @return       Filename of the trackable object
+    */
+	public static native String arwGetTrackableNameAtIndex(int i);
+
+    /**
      * Removes the specified marker.
      *
      * @param trackableUID The unique identifier (UID) of the trackable to remove


### PR DESCRIPTION
Hello,


First of all, thanks a lot for developing ARToolkitX and keeping it opensource.

I've encountered a problem while using the 2D Tracker Android example.

It seems that there's no Java linkage for the C++ _load2DTrackerImageDatabase_, _countTrackables_ and _getTrackableAtIndex_ functions. So actually it is only possible to import JPG trackable files into an Android 2D Marker app.

I've added the necessary links in JNI and it works perfectly, 2D tracker database is being imported.
Thereafter I've edited the 2D Tracker Android sample by transforming the trackableUIDs array to an ArrayList of Integer, and replaced configureARScene() with the following code : 

```
@Override
public boolean configureARScene() {
    int nbTrackables = ARController.getInstance().countTrackables();
    if(nbTrackables <= 0) return false;

    trackableUIDs = new ArrayList<>(nbTrackables);

    for(int i=0; i<nbTrackables; i++) {
        trackableUIDs.add(i,ARController.getInstance().getTrackableUIDAtIndex(i));
        if (trackableUIDs.get(i) < 0) return false;
    }

    return true;
}
```

 Please tell me whether it seems good to you or if there's a neater workaround.


Thanks