### PR TITLE
Fix handling of new marker with high-numbered globalID barcodes. Also…

### DIFF
--- a/Source/ARX/AR/include/ARX/AR/ar.h
+++ b/Source/ARX/AR/include/ARX/AR/ar.h
@@ -214,7 +214,7 @@ typedef struct {
     int             area;                   ///< Area in pixels of the largest connected region, comprising the marker border and regions connected to it. Note that this is not the same as the actual onscreen area inside the marker border.
     int             id;                     ///< If pattern detection mode is either pattern mode OR matrix but not both, will be marker ID (>= 0) if marker is valid, or -1 if invalid.
     int             idPatt;                 ///< If pattern detection mode includes a pattern mode, will be marker ID (>= 0) if marker is valid, or -1 if invalid.
-    int             idMatrix;               ///< If pattern detection mode includes a matrix mode, will be marker ID (>= 0) if marker is valid, or -1 if invalid.
+    int             idMatrix;               ///< If pattern detection mode includes a matrix mode, will be marker ID (>= 0) if marker is valid, or -1 if invalid. If matrixCodeType is AR_MATRIX_CODE_GLOBAL_ID, will be 0 if globalID >= 2^1, or the globalID otherwise.
     int             dir;                    ///< If pattern detection mode is either pattern mode OR matrix but not both, and id != -1, will be marker direction (range 0 to 3, inclusive).
     int             dirPatt;                ///< If pattern detection mode includes a pattern mode, and id != -1, will be marker direction (range 0 to 3, inclusive).
     int             dirMatrix;              ///< If pattern detection mode includes a matrix mode, and id != -1, will be marker direction (range 0 to 3, inclusive).

--- a/Source/ARX/ARTrackableSquare.cpp
+++ b/Source/ARX/ARTrackableSquare.cpp
@@ -410,8 +410,10 @@ bool ARTrackableSquare::getPatternImage(int patternIndex, uint32_t *pattImageBuf
         }
         return true;
     } else  /* patt_type == AR_PATTERN_TYPE_MATRIX */ {
+        if (matrixCodeType == AR_MATRIX_CODE_GLOBAL_ID) return false;
         uint8_t *code;
-        encodeMatrixCode(matrixCodeType, patt_id, &code);
+        int length = encodeMatrixCode(matrixCodeType, patt_id, &code);
+        if (length < 1) return false;
         int barcode_dimensions = matrixCodeType & AR_MATRIX_CODE_TYPE_SIZE_MASK;
         int bit = 0;
 #ifdef AR_LITTLE_ENDIAN

--- a/Source/ARX/ARTrackerSquare.cpp
+++ b/Source/ARX/ARTrackerSquare.cpp
@@ -591,11 +591,12 @@ int ARTrackerSquare::newTrackable(std::vector<std::string> config)
             ARLOGe("Barcode marker config. requires barcode ID.\n");
             return ARTrackable::NO_ID;
         }
-        long barcodeID = strtol(config.at(1).c_str(), NULL, 0);
-        if (barcodeID < 0 || (barcodeID == 0 && (errno == EINVAL || errno == ERANGE))) {
+        uint64_t barcodeID64 = (uint64_t)strtoull(config.at(1).c_str(), NULL, 0); // ull is 64-bit on most 32-bit and 64-bit archs.
+        if (barcodeID64 == 0 && (errno == EINVAL || errno == ERANGE)) {
             ARLOGe("Barcode marker config. specified with invalid ID parameter ('%s').\n", config.at(1).c_str());
             return ARTrackable::NO_ID;
         }
+        int barcodeID = ((barcodeID64 & 0xffffffff80000000ULL) == 0ULL ? (int)barcodeID64 : 0);
         
         // Token 3 is marker width.
         if (config.size() < 3) {
@@ -614,7 +615,7 @@ int ARTrackerSquare::newTrackable(std::vector<std::string> config)
         }
         
         ARTrackableSquare *ret = new ARTrackableSquare();
-        if (!ret->initWithBarcode((int)barcodeID, width)) {
+        if (!ret->initWithBarcode(barcodeID, width, barcodeID64)) {
             // Marker failed to load, or was not added
             delete ret;
             return ARTrackable::NO_ID;

--- a/Source/ARX/ARVideo/cparamSearch.c
+++ b/Source/ARX/ARVideo/cparamSearch.c
@@ -531,7 +531,7 @@ static void *cparamSearchWorker(THREAD_HANDLE_T *threadHandle)
                     reportSQLite3Err(cacheDB);
                     result = CPARAM_SEARCH_STATE_FAILED_ERROR;
                 } else {
-                    sqliteErr = sqlite3_bind_text(stmt, 1, searchData->device_id, -1, SQLITE_STATIC);
+                    sqliteErr = sqlite3_bind_text(stmt, 1, searchData->device_id, -1, SQLITE_STATIC); // Use bind because device_id can contain reserved SQL characters.
                     if (sqliteErr != SQLITE_OK) {
                         reportSQLite3Err(cacheDB);
                         result = CPARAM_SEARCH_STATE_FAILED_ERROR;

--- a/Source/ARX/include/ARX/ARX_c.h
+++ b/Source/ARX/include/ARX/ARX_c.h
@@ -570,8 +570,8 @@ extern "C" {
 	 * @param trackableUID	The unique identifier (UID) of the trackable
 	 * @param patternIndex	The index of the pattern within the trackable, in range from 0 to arwGetTrackablePatternCount() - 1, inclusive. Ignored for trackable types with a single pattern (i.e. 0 assumed).
 	 * @param matrix	The float array to populate with the 4x4 transformation matrix of the pattern (column-major order), or NULL if this value is not required.
-	 * @param width		Pointer to float value to set to the width of the pattern,, or NULL if this value is not required.
-	 * @param height	Pointer to float value to set to the height of the pattern, or NULL if this value is not required.
+	 * @param width		Pointer to float value to set to the width of the pattern,, or NULL if this value is not required. For square markers, this is the width of the border. For 2D and NFT markers, this is the width of the image.
+	 * @param height	Pointer to float value to set to the height of the pattern, or NULL if this value is not required. For square markers, this is the height of the border. For 2D and NFT markers, this is the height of the image.
 	 * @param imageSizeX Pointer to int value to set to the width of the pattern image (in pixels), or NULL if this value is not required.
 	 * @param imageSizeY Pointer to int value to set to the height of the pattern image (in pixels), or NULL if this value is not required.
 	 * @return			true if successful, false if an error occurred


### PR DESCRIPTION
…, reject requests for globalID marker images; these can be generated online only.