### PR TITLE
Android: Update to artoolkitx-built opencv-4.7.0. Ensure consistency …

### DIFF
--- a/Quick start.md
+++ b/Quick start.md
@@ -38,7 +38,7 @@
 * To rebuild the SDK and examples for Linux, in a terminal navigate to `Source` and execute the command `./build.sh linux examples`
 
 ## Android
-* Android Studio 2021 or later with NDK release 21 or later, and an Android device running Android 7.0 or later is required. Defaults to looking for NDK release 26.
+* Android Studio 2021 or later with NDK release 21 or later, and an Android device running Android 7.0 (API level 24) or later is required. Defaults to looking for NDK release 26.1.10909125.
 * Open `Examples` for prebuilt .apks. These may be installed on your device via `adb install *example name*.apk` where EXAMPLE is the example name.
 * An Android Studio project for each example is in `Examples/*example name*/Android`.
 * To rebuild the SDK and examples for Android, in a terminal navigate to `Source` and execute the command `./build.sh android examples`

--- a/Source/ARXJ/ARXJProj/arxj/build.gradle
+++ b/Source/ARXJ/ARXJProj/arxj/build.gradle
@@ -5,6 +5,7 @@ android {
     defaultConfig {
         minSdk 24
         targetSdk 33
+        ndkVersion "26.1.10909125"
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/Source/build.sh
+++ b/Source/build.sh
@@ -216,7 +216,7 @@ if [ "$OS" = "Linux" ] ; then
 fi
 
 if [ ! -d "depends/android/include/opencv2" ] ; then
-    curl --location "https://github.com/artoolkitx/opencv/releases/download/4.6.0/opencv-4.6.0-dev-artoolkitx-android.tgz" -o opencv2.tgz
+    curl --location "https://github.com/artoolkitx/opencv/releases/download/4.7.0-dev-artoolkitx/opencv-4.7.0-dev-artoolkitx-android.tgz" -o opencv2.tgz
     tar xzf opencv2.tgz --strip-components=1 -C depends/android
     rm opencv2.tgz
 fi
@@ -250,6 +250,7 @@ else
                 -DANDROID_ARM_MODE=arm \
                 -DANDROID_ARM_NEON=TRUE \
                 -DANDROID_STL=c++_shared \
+                -DANDROID_CPP_FEATURES="rtti exceptions" \
                 -DCMAKE_BUILD_TYPE=${DEBUG+Debug}${DEBUG-Release}
         fi
 	    cmake --build . --target install${DEBUG-/strip}


### PR DESCRIPTION
…between manual build and gradle-initiated build by specifying ndk version.