### PR TITLE
libdc1394-22-dev is orphaned and replaed by libdc1394-dev

### DIFF
--- a/Source/build.sh
+++ b/Source/build.sh
@@ -453,7 +453,7 @@ if [ $BUILD_LINUX_RASPBIAN ] ; then
             check_package libraspberrypi-dev
             check_package libudev-dev
             check_package libv4l-dev
-            check_package libdc1394-22-dev
+            check_package libdc1394-dev
             check_package libsqlite3-dev
             check_package libcurl4-openssl-dev
         elif (type rpm >/dev/null 2>&1) ; then

--- a/Source/packaging/linux/cpackDEBArtoolkit/lib/CMakeLists.txt
+++ b/Source/packaging/linux/cpackDEBArtoolkit/lib/CMakeLists.txt
@@ -6,7 +6,7 @@ include(../../cpackConfiguration.cmake)
 include(../cpackDebConfiguration.cmake)
 include(../../cpackArtoolkit-libConfiguration.cmake)
 
-set(DEPENDENCIES "libjpeg-dev,libgstreamer1.0-dev,libv4l-dev,libdc1394-22-dev,libgl1-mesa-dev,freeglut3-dev,libopenscenegraph-dev,libopencv-dev,libc6,libcurl3,libsqlite3-0,zlib1g,libudev-dev")
+set(DEPENDENCIES "libjpeg-dev,libgstreamer1.0-dev,libv4l-dev,libdc1394-dev,libgl1-mesa-dev,freeglut3-dev,libopenscenegraph-dev,libopencv-dev,libc6,libcurl3,libsqlite3-0,zlib1g,libudev-dev")
 
 #Include the cmake configuration into the package
 INSTALL(DIRECTORY ${BUILD_ARTEFACTS_DIR}/ARX DESTINATION /usr/lib DIRECTORY_PERMISSIONS

--- a/Source/packaging/linux/cpackDEBArtoolkit/lib/CMakeLists.txt
+++ b/Source/packaging/linux/cpackDEBArtoolkit/lib/CMakeLists.txt
@@ -6,7 +6,7 @@ include(../../cpackConfiguration.cmake)
 include(../cpackDebConfiguration.cmake)
 include(../../cpackArtoolkit-libConfiguration.cmake)
 
-set(DEPENDENCIES "libjpeg-dev,libgstreamer1.0-dev,libv4l-dev,libdc1394-dev,libgl1-mesa-dev,freeglut3-dev,libopenscenegraph-dev,libopencv-dev,libc6,libcurl3,libsqlite3-0,zlib1g,libudev-dev")
+set(DEPENDENCIES "libjpeg-dev,libgstreamer1.0-dev,libv4l-dev,libdc1394-dev,libgl1-mesa-dev,freeglut3-dev,libopenscenegraph-dev,libopencv-dev,libc6,libcurl4,libsqlite3-0,zlib1g,libudev-dev")
 
 #Include the cmake configuration into the package
 INSTALL(DIRECTORY ${BUILD_ARTEFACTS_DIR}/ARX DESTINATION /usr/lib DIRECTORY_PERMISSIONS


### PR DESCRIPTION
This PR fixes ARToolkitX depending on the orphaned package `libdc1394-22-dev` and replaced it with its replacement `libdc1394-dev`

This PR also fixes the .deb package dependency string to correctly request `libcurl4` instead of the outdated version `libcurl3`

As of `Sat, 10 Oct 2020 15:54:54 +0000`

> We believe that the bug you reported is now fixed; the following
> package(s) have been removed from unstable:
> 
> libdc1394-22 |  2.2.5-2.1 | source, amd64, arm64, armel, armhf, i386, mips64el, mipsel, ppc64el, s390x
> libdc1394-22-doc |  2.2.5-2.1 | all
> 
> \------------------- Reason -------------------
> RoQA; Superceded by libdc1394
> \----------------------------------------------

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=963924