### PR TITLE
Fix error.h asserts for C++ >=11 compatibility.

### DIFF
--- a/Source/ARX/KPM/FreakMatcher/framework/error.h
+++ b/Source/ARX/KPM/FreakMatcher/framework/error.h
@@ -65,5 +65,12 @@
 
 //#define isnan(x) ((x) != (x))
 //#define isinf(x) (!isnan(x) && isnan(x - x))
+
+// Since C++11, isnan is part of std namespace.
+#if (__cplusplus >= 201103L)
+#define ASSERT_NAN(x) ASSERT(!(std::isnan(x)), "NaN")
+#define ASSERT_INF(x) ASSERT(!(std::isinf(x)), "INF")
+#else // (__cplusplus >= 201103L)
 #define ASSERT_NAN(x) ASSERT(!isnan(x), "NaN")
 #define ASSERT_INF(x) ASSERT(!isinf(x), "INF")
+#endif // (__cplusplus >= 201103L)


### PR DESCRIPTION
Dear @philip-lamb and other mantainers:

  Please consider to make the FreakMatcher portion buildable on C++ 11 and beyond, I just needed to add a few lines.

## Changes

Fixed error.h asserts that use isnan and isinf without std, which breaks in C++11 and newer standard libraries.

## Motivation

Change is enough to make it build ArtoolkitX completely with FreakMatcher using newer standard library versions.