### PR TITLE
Fix GStreamer ARVideo memory leak

### DIFF
--- a/Source/ARX/ARVideo/GStreamer/videoGStreamer.c
+++ b/Source/ARX/ARVideo/GStreamer/videoGStreamer.c
@@ -95,6 +95,7 @@ static gboolean cb_have_data(GstPad *pad, GstPadProbeInfo *info, gpointer u_data
 		memcpy(vid->videoBuffer, (void *)info->data, info->size);
 		gst_buffer_unmap(buffer, info);
 		/* buffer is not used anymore */
+		gst_buffer_remove_all_memory(buffer);
 	} else {
 		g_print("ARVideo error! Buffer not readable\n");
 	}


### PR DESCRIPTION
Dear @philip-lamb and other mantainers:

Please consider to invoke a clear all memory call after using the buffer, otherwise it starts to allocate memory non-stop frame after frame while using a GStreamer source.

## Changes

Added a "remove_all_memory" call to Source/ARX/ARVideo/GStreamer/videoGStreamer.c that cleans the buffer after it is not used anymore to avoid memory leak.

## Motivation

Change seems to be enough to avoid memory leaks, I left the video running for several minutes and the memory usage did not increase any more.